### PR TITLE
Install etcd from a tarball.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Centos/rhat 6+ & ubuntu with upstart
 
 * *binary_install:* Installs the binary of etcd from a build of etcd from master branch on github
 
+* *tar_install:* Installs the binary of etcd from a release tar.gz.
+
 ## Usage 
 For now just use default. In the future that might change.
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,6 +5,8 @@
 case node[:etcd][:install_method]
 when "binary"
   include_recipe "etcd::binary_install"
+when "tar"
+  include_recipe "etcd::tar_install"
 else
   log "Install Method not supported for etcd yet: #{node[:etcd][:install_method]}" do
     level :warn

--- a/recipes/tar_install.rb
+++ b/recipes/tar_install.rb
@@ -1,0 +1,44 @@
+#
+# Installs etcd from a tar
+#
+
+cache_path = Chef::Config[:file_cache_path]
+tar_file = "#{cache_path}/#{File.basename node[:etcd][:url]}"
+
+remote_file tar_file do
+  mode "755"
+  source node[:etcd][:url]
+  action :nothing
+  notifies :run, "execute[extract]", :immediately
+end
+
+# extracts are into /tmp/etcd. We remove and recreate this every time because
+# the tars contain a subdirectory and we've got to make sure our find only
+# finds the current version.
+execute "extract" do
+  user "root"
+  group "root"
+  cwd '/tmp'
+  command %{rm -rf ./etcd && mkdir ./etcd && tar zxf #{tar_file} -C ./etcd}
+  action :nothing
+  notifies :run, "execute[move]", :immediately
+end
+
+execute "move" do
+  user "root"
+  group "root"
+  cwd '/tmp'
+  command %{find ./etcd -type f -name etcd -exec mv {} /usr/bin \\;}
+  creates node[:etcd][:bin]
+  action :nothing
+end
+
+http_request "HEAD #{node[:etcd][:url]}" do
+  message ""
+  url node[:etcd][:url]
+  action :head
+  if File.exists?(tar_file)
+    headers "If-Modified-Since" => File.mtime(tar_file).httpdate
+  end
+  notifies :create, "remote_file[#{tar_file}]", :immediately
+end


### PR DESCRIPTION
Fixes #1.

This change adds another recipe, `tar_install`, which installs etcd from a tarball. I've tested it against the v0.1.0 release from github.

```
node[:etcd][:url] = 'https://github.com/coreos/etcd/releases/download/v0.1.0/etcd-v0.1.0-Linux.tar.gz'
```
