### PR TITLE
add source install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Centos/rhat 6+ & ubuntu with upstart
 * *default:* Install and setup the service
 * *_service:* Recipe used by default for setting up the service
 * *binary_install:* Installs the binary of etcd from github release tarballs
+* *source_install:* Compiles the binary of etcd from a specificed github repo/revision
 * *cluster:* Recipe to aide in the building of multi-node etcd clusters
 
 ## Attributes
 
 | attribute | default setting | description | 
 |:---------------------------------|:---------------|:-----------------------------------------|
-|`default[:etcd][:install_method]`| binary | Right now only binary is supported. In the future this will probably go away as there are actual distro packages |
+|`default[:etcd][:install_method]`| binary | Right now only binary and source are supported. In the future this will probably go away as there are actual distro packages |
 |`default[:etcd][:args]`|  -c 0.0.0.0:4001 -s 0.0.0.0:70001 | Arguments to pass to etcd when starting the service. |
 |`default[:etcd][:name_switch]`| -n | The switch used to specify the node or hostname to etcd. if you build from source this switch has changed since the 0.1.0 release. I will remove this when the arguments to etcd stabilize|
 |`default[:etcd][:version]` | 0.1.0 | The release versions to install. binary install will assemble a github url to grab this version |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,3 +21,11 @@ default[:etcd][:sha256] = "5c25b863bd3d87a5352cf0a2ae3e1c453cc3c9fc3d880694c20da
 default[:etcd][:url] = nil
 
 default[:etcd][:state_dir] = "/var/cache/etcd/state"
+
+# Used for source_install method
+default[:etcd][:source][:repo] = "https://github.com/coreos/etcd"
+default[:etcd][:source][:revision] = "HEAD"
+default[:etcd][:source][:go_ver] = "1.1.2"
+default[:etcd][:source][:go_url] = nil
+default[:etcdctl][:source][:repo] = "https://github.com/coreos/etcdctl"
+default[:etcdctl][:source][:revision] = "HEAD"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,9 +5,11 @@
 case node[:etcd][:install_method]
 when "binary"
   include_recipe "etcd::binary_install"
+when "source"
+  include_recipe "etcd::source_install"
 else
   log "Install Method not supported: #{node[:etcd][:install_method]}" do
-    level :warn
+    level :fatal
   end
 end
 

--- a/recipes/source_install.rb
+++ b/recipes/source_install.rb
@@ -1,0 +1,52 @@
+#
+# Installs etcd from source
+#
+
+# install go
+version = node[:etcd][:source][:go_ver]
+package = "go#{version}.linux-#{node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"}.tar.gz"
+url = "https://go.googlecode.com/files/#{package}"
+if node[:etcd][:source][:go_url]
+  url = node[:etcd][:source][:go_url]
+end
+
+ark "go" do
+  version node[:etcd][:source][:go_ver]
+  url url
+  append_env_path true
+  action :nothing
+end.run_action(:install) 
+
+# checkout from git
+git "#{Chef::Config[:file_cache_path]}/etcd" do
+  repository node[:etcd][:source][:repo]
+  reference node[:etcd][:source][:revision]
+  action :sync
+  notifies :run, "bash[compile_etcd]"
+end
+
+git "#{Chef::Config[:file_cache_path]}/etcdctl" do
+  repository node[:etcdctl][:source][:repo]
+  reference node[:etcdctl][:source][:revision]
+  action :sync
+  notifies :run, "bash[compile_etcdctl]"
+end
+
+# build and 'install'
+bash "compile_etcd" do
+  user "root"
+  cwd "#{Chef::Config[:file_cache_path]}/etcd"
+  code <<-EOH
+  ./build
+  mv etcd /usr/local/bin/
+  EOH
+end
+
+bash "compile_etcdctl" do
+  user "root"
+  cwd "#{Chef::Config[:file_cache_path]}/etcdctl"
+  code <<-EOH
+  ./build
+  mv etcdctl /usr/local/bin/
+  EOH
+end


### PR DESCRIPTION
Install `etcd` and `etcdctl` from git source. 

Made attributes for most things so an alternative git repo can be used. 

Go 1.1+ is required to build `etcd` so elected to download these as binaries.

Also changed the warning on 'install method not supported' to `fatal` as the run will abort soon afterwards due to the service not being able to be created when `etcd` isn't installed.
