### PR TITLE
Change upstart script to start on networking

### DIFF
--- a/templates/default/etcd.conf.erb
+++ b/templates/default/etcd.conf.erb
@@ -1,6 +1,6 @@
 description "etcd service registry"
 
-start on started
+start on started networking
 stop on shutdown
 
 exec /usr/local/bin/etcd <%= @args %> -d <%= node[:etcd][:state_dir] %> -n <%= node[:fqdn] %>


### PR DESCRIPTION
Currently etcd starts before networking; networking should start first so that etcd can listen on the configured interfaces.
