### PR TITLE
Add auto-respawn instruction in upstart config file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,9 @@ default[:etcd][:upstart][:stop_on] = 'shutdown'
 # Release to install
 default[:etcd][:version] = '0.3.0'
 
+# Auto respawn
+default[:etcd][:respawn] = false
+
 # Sha for github tarball Linux by default
 default[:etcd][:sha256] = '18be476ba59db42c573ee23fbe00f4a205830ac54f752c0d46280707603c9192'
 

--- a/templates/default/etcd.conf.erb
+++ b/templates/default/etcd.conf.erb
@@ -1,5 +1,9 @@
 description "etcd service registry"
 
+<%- if node[:etcd][:respawn] %>
+respawn
+<%- end %>
+
 start on <%= node[:etcd][:upstart][:start_on] %>
 stop on <%= node[:etcd][:upstart][:stop_on] %>
 


### PR DESCRIPTION
As etcd is still quite young it happens that it crashes.

It would be interesting to allow us to make it respawn automatically
