### PR TITLE
Bump default etcd version to 0.4.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,7 @@ default[:etcd][:upstart][:start_on] = 'started networking'
 default[:etcd][:upstart][:stop_on] = 'shutdown'
 
 # Release to install
-default[:etcd][:version] = '0.3.0'
+default[:etcd][:version] = '0.4.1'
 
 # Auto respawn
 default[:etcd][:respawn] = false


### PR DESCRIPTION
This new version has been released and provided a greater stability,
I think we can use it as default installed version for this cookbook
