### PR TITLE
Create a trigger_start option for disabling starting on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Centos/rhat 6+ & ubuntu with upstart
 |`default[:etcd][:state_dir]` | `/var/cache/etcd/state` | Where etcd will store its state |
 |`default[:etcd][:search_cook]`| `'etcd\:\:cluster'` | The cookbook that should be searched for on the nodes recipes to detect if it is also running etcd |
 |`default[:etcd][:trigger_restart]` | `true` | Make etcd restart if the init config is updated
+|`default[:etcd][:trigger_start]` | `true` | Make etcd start during this run
 |`default[:etcd][:upstart][:start_on]` | `started networking` | When to start the etcd service using upstart
 |`default[:etcd][:upstart][:stop_on]` | `shutdown` | When to stop the etcd service using upstart
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,9 @@ default[:etcd][:snapshot] = true
 # restart etcd when the config file is updated
 default[:etcd][:trigger_restart] = true
 
+# start etcd when etcd is first installed
+default[:etcd][:trigger_start] = true
+
 # Upstart parameters for starting/stopping etcd service
 default[:etcd][:upstart][:start_on] = 'started networking'
 default[:etcd][:upstart][:stop_on] = 'shutdown'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -69,5 +69,5 @@ end
 service 'etcd' do
   provider init_provider
   supports status: true, restart: true, reload: true
-  action [:enable, :start]
+  action [:enable, :start] if node[:etcd][:trigger_start]
 end


### PR DESCRIPTION
I'm building AMIs using this chef cookbook. By hard-coding the discovery URL and starting the daemon on the first install causes the discovery URL to be invalidated, since the machine joins and then exits the cluster.

Adding the `trigger_start` option resolves this issue.
