### PR TITLE
Log stderr under upstart

### DIFF
--- a/templates/default/upstart/etcd.conf.erb
+++ b/templates/default/upstart/etcd.conf.erb
@@ -8,6 +8,7 @@ limit nproc 524288 1048576
 respawn
 respawn limit 2 10
 
-script
-  exec su -c "<%= @etcd_cmd %> >> <%= @config.logfile %>" <%= @config.run_user %>
-end script
+setuid <%= @config.run_user %>
+setgid <%= @config.run_user %>
+
+exec <%= @etcd_cmd %> >> <%= @config.logfile %> 2>&1


### PR DESCRIPTION
The Etcd stderr output should be explicitly redirected to stdout, otherwise it does not get to the log file. Besides rather than do `su -c`, it makes sense to use the standard upstart way to set the run user.