### PR TITLE
Add etcdctl options for TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ found in
 - `peer_key_file`
 - `peer_client_cert_auth`
 - `peer_trusted_ca_file`
+- `etcdctl_client_cert_file`
+- `etcdctl_client_key_file`
 
 - Logging Flags
 - `debug`

--- a/libraries/etcd_service_base.rb
+++ b/libraries/etcd_service_base.rb
@@ -57,6 +57,8 @@ module EtcdCookbook
     property :peer_key_file, String, desired_state: false
     property :peer_client_cert_auth, Boolean, default: false, desired_state: false
     property :peer_trusted_ca_file, String, desired_state: false
+    property :etcdctl_client_cert_file, String, desired_state: false
+    property :etcdctl_client_key_file, String, desired_state: false
 
     # Logging Flags
     property :debug, Boolean, default: false, desired_state: false

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -66,6 +66,10 @@ module EtcdCookbook
 
       def etcdctl_opts
         opts = []
+	# The client cert must be the same file as the server cert
+	opts << "--ca-file=#{trusted_ca_file}" if client_cert_auth == true
+	opts << "--cert-file=#{cert_file}" if client_cert_auth == true
+	opts << "--key-file=#{key_file}" if client_cert_auth == true
         opts << "-C #{advertise_client_urls}" if advertise_client_urls
       end
 

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -68,8 +68,8 @@ module EtcdCookbook
         opts = []
 	# The client cert must be the same file as the server cert
 	opts << "--ca-file=#{trusted_ca_file}" if client_cert_auth == true
-	opts << "--cert-file=#{cert_file}" if client_cert_auth == true
-	opts << "--key-file=#{key_file}" if client_cert_auth == true
+	opts << "--cert-file=#{etcdctl_client_cert_file}" if client_cert_auth == true
+	opts << "--key-file=#{etcdctl_client_key_file}" if client_cert_auth == true
         opts << "-C #{advertise_client_urls}" if advertise_client_urls
       end
 


### PR DESCRIPTION
When running a TLS-enabled server, the startup scripts require a client certificate to auth against the server. This PR provides the ability to do that through the `etcd_service` provider.