### PR TITLE
Package install support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/libraries/etcd_installation_package.rb
+++ b/libraries/etcd_installation_package.rb
@@ -1,0 +1,25 @@
+module EtcdCookbook
+  class EtcdInstallationDocker < ChefCompat::Resource
+    resource_name :etcd_installation_package
+
+    action :create do
+      case node[:platform]
+      when 'centos'
+        package 'etcd'
+      else 
+        Chef::Exceptions::UnsupportedPlatform    
+      end
+    end
+
+    action :delete do
+      case node[:platform]
+      when 'centos'
+        package 'etcd' do
+          action :purge
+        end
+      else 
+        Chef::Exceptions::UnsupportedPlatform        
+      end
+    end
+  end
+end

--- a/libraries/etcd_installation_package.rb
+++ b/libraries/etcd_installation_package.rb
@@ -1,5 +1,5 @@
 module EtcdCookbook
-  class EtcdInstallationDocker < ChefCompat::Resource
+  class EtcdInstallationPackage < ChefCompat::Resource
     resource_name :etcd_installation_package
 
     action :create do

--- a/libraries/etcd_installation_package.rb
+++ b/libraries/etcd_installation_package.rb
@@ -6,8 +6,8 @@ module EtcdCookbook
       case node[:platform]
       when 'centos'
         package 'etcd'
-      else 
-        Chef::Exceptions::UnsupportedPlatform    
+      else
+        Chef::Exceptions::UnsupportedPlatform
       end
     end
 
@@ -17,8 +17,8 @@ module EtcdCookbook
         package 'etcd' do
           action :purge
         end
-      else 
-        Chef::Exceptions::UnsupportedPlatform        
+      else
+        Chef::Exceptions::UnsupportedPlatform
       end
     end
   end

--- a/libraries/etcd_service_base.rb
+++ b/libraries/etcd_service_base.rb
@@ -39,6 +39,7 @@ module EtcdCookbook
     property :discovery_srv, String, desired_state: false
     property :discovery_fallback, String, desired_state: false
     property :discovery_proxy, String, desired_state: false
+    property :strict_reconfig_check, Boolean, default: false, desired_state: false
 
     # Proxy Flags
     property :proxy, String, desired_state: false
@@ -60,6 +61,7 @@ module EtcdCookbook
 
     # Logging Flags
     property :debug, Boolean, default: false, desired_state: false
+    property :log_package_levels, String, desired_state: false
 
     # Unsafe Flags
     property :force_new_cluster, Boolean, default: false, desired_state: false

--- a/libraries/etcd_service_conffile.rb
+++ b/libraries/etcd_service_conffile.rb
@@ -5,20 +5,60 @@ module EtcdCookbook
     provides :etcd_service_manager, platform: 'centos'
 
     action :create do
-      service 'etcd' do
+      # Create service template
+      template "/lib/systemd/system/#{etcd_name}.service" do
+        source 'systemd/etcd.service.conffile.erb'
+        owner 'root'
+        group 'root'
+        mode '0644'
+        variables(
+          config: new_resource,
+          etcd_name: etcd_name,
+          etcd_bin: etcd_bin
+        )
+        cookbook 'etcd'
+        notifies :run, 'execute[systemctl daemon-reload]', :immediately
+        notifies :restart, new_resource if auto_restart
+        action :create
+      end
+
+      # Register this service within Chef
+      service etcd_name do
         supports restart: true, status: true
         action [:enable]
       end
 
-      template "/etc/etcd/etcd.conf" do
+      # Create config file
+      template "/etc/etcd/#{etcd_name}.conf" do
         cookbook 'etcd'
         source 'etcd.conf.erb'
         owner 'root'
         group 'root'
         mode '0755'
-        notifies :restart, 'service[etcd]'
+        notifies :restart, new_resource
         variables config: new_resource
       end
+
+      # Avoid 'Unit file changed on disk' warning
+      execute 'systemctl daemon-reload' do
+        command '/bin/systemctl daemon-reload'
+        action :nothing
+      end
     end
+
+    action :start do
+      service etcd_name do
+        action [:start]
+      end
+    end
+    
+    action :stop do
+    end
+
+    action :restart do
+      action_stop
+      action_start
+    end
+
   end
 end

--- a/libraries/etcd_service_conffile.rb
+++ b/libraries/etcd_service_conffile.rb
@@ -23,7 +23,7 @@ module EtcdCookbook
       end
 
       # Register this service within Chef
-      service etcd_name do
+      service 'etcd' do
         supports restart: true, status: true
         action [:enable]
       end

--- a/libraries/etcd_service_conffile.rb
+++ b/libraries/etcd_service_conffile.rb
@@ -1,0 +1,24 @@
+module EtcdCookbook
+  class EtcdServiceConfFile < EtcdServiceBase
+    resource_name :etcd_service_conffile
+
+    provides :etcd_service_manager, platform: 'centos'
+
+    action :create do
+      service 'etcd' do
+        supports restart: true, status: true
+        action [:enable]
+      end
+
+      template "/etc/etcd/etcd.conf" do
+        cookbook 'etcd'
+        source 'etcd.conf.erb'
+        owner 'root'
+        group 'root'
+        mode '0755'
+        notifies :restart, 'service[etcd]'
+        variables config: new_resource
+      end
+    end
+  end
+end

--- a/libraries/etcd_service_conffile.rb
+++ b/libraries/etcd_service_conffile.rb
@@ -51,7 +51,7 @@ module EtcdCookbook
         action [:start]
       end
     end
-    
+
     action :stop do
     end
 
@@ -59,6 +59,5 @@ module EtcdCookbook
       action_stop
       action_start
     end
-
   end
 end

--- a/libraries/etcd_service_conffile.rb
+++ b/libraries/etcd_service_conffile.rb
@@ -6,7 +6,7 @@ module EtcdCookbook
 
     action :create do
       # Create service template
-      template "/lib/systemd/system/#{etcd_name}.service" do
+      template "/lib/systemd/system/etcd.service" do
         source 'systemd/etcd.service.conffile.erb'
         owner 'root'
         group 'root'
@@ -35,7 +35,7 @@ module EtcdCookbook
         owner 'root'
         group 'root'
         mode '0755'
-        notifies :restart, new_resource
+        notifies :restart, new_resource if auto_restart
         variables config: new_resource
       end
 

--- a/templates/default/etcd.conf.erb
+++ b/templates/default/etcd.conf.erb
@@ -1,0 +1,120 @@
+# [member]
+<% if @config.node_name -%>
+ETCD_NAME="<%= @config.node_name %>"
+<% end -%>
+<% if @config.data_dir -%>
+ETCD_DATA_DIR="<%= @config.data_dir %>"
+<% end -%>
+<% if @config.wal_dir -%>
+ETCD_WAL_DIR="<%= @config.wal_dir %>"
+<% end -%>
+<% if @config.snapshot_count -%>
+ETCD_SNAPSHOT_COUNT="<%= @config.snapshot_count %>"
+<% end -%>
+<% if @config.heartbeat_interval -%>
+ETCD_HEARTBEAT_INTERVAL="<%= @config.heartbeat_interval %>"
+<% end -%>
+<% if @config.election_timeout -%>
+ETCD_ELECTION_TIMEOUT="<%= @config.election_timeout %>"
+<% end -%>
+<% if @config.listen_peer_urls -%>
+ETCD_LISTEN_PEER_URLS="<%= @config.listen_peer_urls %>"
+<% end -%>
+<% if @config.listen_client_urls -%>
+ETCD_LISTEN_CLIENT_URLS="<%= @config.listen_client_urls %>"
+<% end -%>
+<% if @config.max_snapshots -%>
+ETCD_MAX_SNAPSHOTS="<%= @config.max_snapshots %>"
+<% end -%>
+<% if @config.max_wals -%>
+ETCD_MAX_WALS="<%= @config.max_wals %>"
+<% end -%>
+<% if @config.cors -%>
+ETCD_CORS="<%= @config.cors %>"
+<% end -%>
+
+#[cluster]
+<% if @config.initial_advertise_peer_urls -%>
+ETCD_INITIAL_ADVERTISE_PEER_URLS="<%= @config.initial_advertise_peer_urls %>"
+<% end -%>
+<% if @config.initial_cluster -%>
+ETCD_INITIAL_CLUSTER="<%= @config.initial_cluster %>"
+<% end -%>
+<% if @config.initial_cluster_state -%>
+ETCD_INITIAL_CLUSTER_STATE="<%= @config.initial_cluster_state %>"
+<% end -%>
+<% if @config.initial_cluster_token -%>
+ETCD_INITIAL_CLUSTER_TOKEN="<%= @config.initial_cluster_token %>"
+<% end -%>
+<% if @config.advertise_client_urls -%>
+ETCD_ADVERTISE_CLIENT_URLS="<%= @config.advertise_client_urls %>"
+<% end -%>
+<% if @config.discovery -%>
+ETCD_DISCOVERY="<%= @config.discovery %>"
+<% end -%>
+<% if @config.discovery_srv -%>
+ETCD_DISCOVERY_SRV="<%= @config.discovery_srv %>"
+<% end -%>
+<% if @config.discovery_fallback -%>
+ETCD_DISCOVERY_FALLBACK="<%= @config.discovery_fallback %>"
+<% end -%>
+<% if @config.discovery_proxy -%>
+ETCD_DISCOVERY_PROXY="<%= @config.discovery_proxy %>"
+<% end -%>
+<% if @config.strict_reconfig_check -%>
+ETCD_STRICT_RECONFIG_CHECK="<%= @config.strict_reconfig_check %>"
+<% end -%>
+
+#[proxy]
+<% if @config.proxy -%>
+ETCD_PROXY="<%= @config.proxy %>"
+<% end -%>
+<% if @config.proxy_failure_wait -%>
+ETCD_PROXY_FAILURE_WAIT="<%= @config.proxy_failure_wait %>"
+<% end -%>
+<% if @config.proxy_refresh_interval -%>
+ETCD_PROXY_REFRESH_INTERVAL="<%= @config.proxy_refresh_interval %>"
+<% end -%>
+<% if @config.proxy_dial_timeout -%>
+ETCD_PROXY_DIAL_TIMEOUT="<%= @config.proxy_dial_timeout %>"
+<% end -%>
+<% if @config.proxy_write_timeout -%>
+ETCD_PROXY_WRITE_TIMEOUT="<%= @config.proxy_write_timeout %>"
+<% end -%>
+<% if @config.proxy_read_timeout -%>
+ETCD_PROXY_READ_TIMEOUT="<%= @config.proxy_read_timeout %>"
+<% end -%>
+
+#[security]
+<% if @config.cert_file -%>
+ETCD_CERT_FILE="<%= @config.cert_file %>"
+<% end -%>
+<% if @config.key_file -%>
+ETCD_KEY_FILE="<%= @config.key_file %>"
+<% end -%>
+<% if @config.client_cert_auth -%>
+ETCD_CLIENT_CERT_AUTH="<%= @config.client_cert_auth %>"
+<% end -%>
+<% if @config.trusted_ca_file -%>
+ETCD_TRUSTED_CA_FILE="<%= @config.trusted_ca_file %>"
+<% end -%>
+<% if @config.peer_cert_file -%>
+ETCD_PEER_CERT_FILE="<%= @config.peer_cert_file %>"
+<% end -%>
+<% if @config.peer_key_file -%>
+ETCD_PEER_KEY_FILE="<%= @config.peer_key_file %>"
+<% end -%>
+<% if @config.peer_client_cert_auth -%>
+ETCD_PEER_CLIENT_CERT_AUTH="<%= @config.peer_client_cert_auth %>"
+<% end -%>
+<% if @config.peer_trusted_ca_file -%>
+ETCD_PEER_TRUSTED_CA_FILE="<%= @config.peer_trusted_ca_file %>"
+<% end -%>
+
+#[logging]
+<% if @config.debug -%>
+ETCD_DEBUG="<%= @config.debug %>"
+<% end -%>
+<% if @config.log_package_levels -%>
+ETCD_LOG_PACKAGE_LEVELS="<%= @config.log_package_levels %>"
+<% end -%>

--- a/templates/default/systemd/etcd.service.conffile.erb
+++ b/templates/default/systemd/etcd.service.conffile.erb
@@ -1,0 +1,20 @@
+[Unit]
+Description=Etcd Server
+After=network.target
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+WorkingDirectory=/var/lib/etcd/
+EnvironmentFile=-/etc/etcd/<%= @etcd_name %>.conf
+<% if @config.run_user -%>
+User=<%= @config.run_user %>
+<% end -%>
+# set GOMAXPROCS to number of processors
+ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) <%= @etcd_bin %> --name=\"${ETCD_NAME}\" --data-dir=\"${ETCD_DATA_DIR}\" --listen-client-urls=\"${ETCD_LISTEN_CLIENT_URLS}\""
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi. CentOS provides a pre-packaged etcd, and i'm quite sure that the packages are also available for Red Hat and Fedora. Using those packages can be one of the install options. 
In these packages they provide the config file, which is basically a template for env variables. Template for the config file is included together with the systemd unit file template that utilizes this file.
Also, there were two options missing, log_package_levels and strict_reconfig_check.