### PR TITLE
Fix checksum property on etcd_installation resource

### DIFF
--- a/libraries/etcd_installation_binary.rb
+++ b/libraries/etcd_installation_binary.rb
@@ -23,6 +23,7 @@ module EtcdCookbook
       remote_file 'etcd tarball' do
         path "#{file_cache_path}/etcd-v#{new_resource.version}-linux-amd64.tar.gz"
         source new_resource.source
+        checksum new_resource.checksum
         action :create
       end
 


### PR DESCRIPTION
### Description

Fixes the checksum property on etcd_installation resource. Previously it was being ignored

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
