### PR TITLE
Wire-up service_timeout property to systemd timeoutstartsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ end
 
 #### properties
 
-- service_timeout - The time in seconds before the service start fails. Default: 20
+- service_timeout - The time in seconds before the service start fails. Default: 120
 - ignore_failure - Ignore failures starting the etcd service. Before quorum is established nodes will loop indefinitely and never successfully start. This can help ensure all instances are up when init systems can handle restart on failure. Default: false
 
 ### etcd_service_manager_docker

--- a/libraries/etcd_service_manager_systemd.rb
+++ b/libraries/etcd_service_manager_systemd.rb
@@ -6,7 +6,7 @@ module EtcdCookbook
       Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
     end
 
-    property :service_timeout, Integer, default: 20
+    property :service_timeout, Integer, default: 120
 
     action :start do
       user 'etcd' do
@@ -51,7 +51,7 @@ module EtcdCookbook
           LimitNOFILE: '1048576',
           LimitNPROC: '1048576',
           LimitCORE: 'infinity',
-          TimeoutStartSec: '120',
+          TimeoutStartSec: new_resource.service_timeout.to_s,
         },
         Install: {
           WantedBy: 'multi-user.target',


### PR DESCRIPTION
Signed-off-by: Matt Kulka <mkulka@parchment.com>

### Description

This property was previously used but the startup wrapper script was removed. Wire up
the property to systemd unit's TimeoutStartSec and change default to match prior hardcoded value.

### Issues Resolved

Fixes #83

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>