### PR TITLE
Adding peer-cert-allowed-cn new option in allowed resources properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The `etcd_service` resource property list corresponds to the options found in
 - `peer_key_file`
 - `peer_client_cert_auth`
 - `peer_trusted_ca_file`
+- `peer_cert_allowed_cn`
 - `peer_auto_tls`
 - `etcdctl_client_cert_file`
 - `etcdctl_client_key_file`

--- a/libraries/etcd_common_properties.rb
+++ b/libraries/etcd_common_properties.rb
@@ -61,6 +61,7 @@ module EtcdCookbook
         property :client_cert_auth, [true, false], default: false, desired_state: false
         property :trusted_ca_file, String, desired_state: false
         property :auto_tls, [true, false], default: false, desired_state: false
+	property :peer_cert_allowed_cn, String, desired_state: false
         property :peer_cert_file, String, desired_state: false
         property :peer_key_file, String, desired_state: false
         property :peer_client_cert_auth, [true, false], default: false, desired_state: false

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -39,6 +39,7 @@ module EtcdCookbook
         opts << "-listen-peer-urls=#{new_resource.listen_peer_urls}" unless new_resource.listen_peer_urls.nil?
         opts << "-max-snapshots=#{new_resource.max_snapshots}" unless new_resource.max_snapshots.nil?
         opts << "-max-wals=#{new_resource.max_wals}" unless new_resource.max_wals.nil?
+	opts << "-peer-cert-allowed-cn=#{new_resource.peer_cert_allowed_cn}" unless new_resource.peer_cert_allowed_cn?
         opts << "-peer-cert-file=#{new_resource.peer_cert_file}" unless new_resource.peer_cert_file.nil?
         opts << '-peer-client-cert-auth=true' if new_resource.peer_client_cert_auth == true
         opts << "-peer-key-file=#{new_resource.peer_key_file}" unless new_resource.peer_key_file.nil?


### PR DESCRIPTION
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the
    best of my knowledge, is covered under an appropriate open
    source license and I have the right under that license to
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as
    Indicated in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
